### PR TITLE
fixes problem with Gemfile definition (previous version didn't work)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,3 @@
-builder
+source 'https://rubygems.org'
+
+gem 'builder'


### PR DESCRIPTION
The previous version of the Gemfile added in a recent commit didn't work when a "bundle install" command was run; this patch fixes that issue
