### PR TITLE
Fixing LICENSE file so that the copyright notice is correct

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
-Occam MicroKernel - Copyright (C) 2014 Computer Sciences Corporation
+Occam MicroKernel - Copyright (C) 2012-2014 Puppet Labs LLC
+                    Copyright (C) 2014 Computer Sciences Corporation
 
 Computer Sciences Corproation can be contacted at: info@csc.com
 


### PR DESCRIPTION
Fixing LICENSE file so that both the old (Puppet Labs) and new (CSC) copyright notices are included
