### PR TITLE
Fixes #9 (Support use of the SMBIOS UUID as a node identifier)

### DIFF
--- a/hanlon_microkernel/hnl_mk_fact_manager.rb
+++ b/hanlon_microkernel/hnl_mk_fact_manager.rb
@@ -39,20 +39,43 @@ module HanlonMicrokernel
       @last_saved_timestamp = Time.now
     end
 
-    def get_hw_id_array
-      hw_id_array = []
+    def get_mac_id_array
+      mac_id_array = []
       # get a list of the IP interfaces from Facter
       interface_array = Facter::Util::IP.get_interfaces
       # for each interface...
       interface_array.each { |interface|
         # if the name of the interface starts with the string 'eth' and is followed by
-        # one or more numbers, add the MAC address for that interface to the hw_id_array
+        # one or more numbers, add the MAC address for that interface to the mac_id_array
         if /^eth[0-9]+$/.match(interface)
           mac_address = Facter::Util::IP.get_interface_value(interface,'macaddress')
-          hw_id_array << mac_address if mac_address
+          mac_id_array << mac_address if mac_address
         end
       }
-      hw_id_array.join('_').gsub(/:/,'')
+      mac_id_array.join('_').gsub(/:/,'')
+    end
+
+    def get_uuid
+      # loop through output of 'lshw -c system' command
+      %x[sudo lshw -c system].each { |line|
+        # check for line that includes the configuration (which has the
+        # uuid value embedded in it)
+        config_line_val = /^[ ]+configuration:\s+(.+)/.match(line)
+        if config_line_val && config_line_val[1]
+          # if got this far, then split the match into elements, each
+          # of which will look like "name=value"; then look for the
+          # element who's 'name' is 'uuid'
+          config_line_val[1].split.each { |elem|
+            uuid_elem_match = /^uuid=(.+)$/.match(elem)
+            if uuid_elem_match
+              # if got this far, we've found a match
+              return uuid_elem_match[1]
+            end
+          }
+        end
+      }
+      # if we got to here, no uuid was found, so return an empty string
+      ''
     end
 
   end

--- a/hanlon_microkernel/hnl_mk_registration_manager.rb
+++ b/hanlon_microkernel/hnl_mk_registration_manager.rb
@@ -65,7 +65,8 @@ module HanlonMicrokernel
         # The array passed through this "hw_id" key in the JSON hash is constructed by the
         # FactManager.  Currently, it includes a list of all of the network interfaces that
         # have names that look like 'eth[0-9]+', but that may change down the line.
-        json_hash["hw_id"] = @fact_manager.get_hw_id_array
+        json_hash["mac_id"] = @fact_manager.get_mac_id_array
+        json_hash["uuid"] = @fact_manager.get_uuid
         json_hash["attributes_hash"] = fact_map
         json_hash["last_state"] = last_state
         json_string = JSON.generate(json_hash)

--- a/hnl_mk_control_server.rb
+++ b/hnl_mk_control_server.rb
@@ -238,14 +238,17 @@ loop do
     # if the checkin_uri was defined, then send a "checkin" message to the server
     if checkin_uri
 
-      # Note: as of v0.7.0.0 of the Microkernel, the system is no longer identified using
-      # a Microkernel-defined UUID value.  Instead, the Microkernel reports an array
-      # containing "hw_id" information to the Hanlon server and the Hanlon server uses that
-      # information to construct the UUID that the system will be (or is) mapped to.
-      # The array passed through this "hw_id" key in the JSON hash is constructed by the
-      # FactManager.  Currently, it includes a list of all of the network interfaces that
-      # have names that look like 'eth[0-9]+', but that may change down the line.
-      hw_id = fact_manager.get_hw_id_array
+      # Note: as of v1.1 of the Microkernel, the system is no longer identified using
+      # a Microkernel-defined "hw_id" value.  Instead, the Microkernel reports an array
+      # containing both the "mac_id" information (previously known as the "hw_id") and
+      # a string containing the UUID (from the BIOS) to the Hanlon server and the Hanlon
+      # server saves that information, along with a Hanlon-generated UUID that the system
+      # will be (or is) mapped to.  The string representation of the "mac_id" option in the
+      # checkin URI is constructed by the FactManager.  Currently, it includes a list of all
+      # of the network interfaces that have names that look like 'eth[0-9]+', but that may
+      # change down the line.
+      mac_id = fact_manager.get_mac_id_array
+      uuid = fact_manager.get_uuid
 
       # check to see if this is the first checkin or not (this flag will be true until the
       # node successfully registers for the first time after boot, after that it will be
@@ -253,7 +256,7 @@ loop do
       is_first_checkin = is_first_checkin?
 
       # construct the checkin_uri_string
-      checkin_uri_string = checkin_uri + "?hw_id=#{hw_id}&last_state=#{idle}"
+      checkin_uri_string = checkin_uri + "?uuid=#{uuid}&mac_id=#{mac_id}&last_state=#{idle}"
       checkin_uri_string << "&first_checkin=#{is_first_checkin}" if is_first_checkin
       logger.info "checkin_uri_string = #{checkin_uri_string}"
       uri = URI checkin_uri_string


### PR DESCRIPTION
The changes in this pull request modify the Hanlon Microkernel so that it reports its (SMBIOS) UUID, in addition to the old MAC-address-based hardware identifier that was previously reported, to Hanlon as part of it's checkin and registration requests. The old (MAC-address-based) hardware identifier is reported using the new `mac_id` parameter (instead of the old `hw_id` parameter) while the (SMBIOS) UUID value is reported using the new `uuid` parameter. The changes in this PR are necessary to enable the use of the (SMBIOS) UUID as the hardware identifier for the node in Hanlon (enabled by the changes in csc/Hanlon/#161), but Hanlon will work without these changes (it will just continue to use the old MAC-address-based field instead).
