### PR TITLE
Adding poweroff command for use in noop model/policy

### DIFF
--- a/hnl_mk_control_server.rb
+++ b/hnl_mk_control_server.rb
@@ -299,6 +299,10 @@ loop do
           # reboots the node, NOW...no sense in logging this since the "filesystem"
           # is all in memory and will disappear when the reboot happens
           %x[sudo reboot now]
+        elsif command == "poweroff" then
+          # powers off the node, NOW...no sense in logging this since the "filesystem"
+          # is all in memory and will disappear when the poweroff happens
+          %x[sudo poweroff now]
         end
 
         # next, check the configuration that is included in the response...


### PR DESCRIPTION
This pull request adds a `poweroff` command to the list of commands supported by the Microkernel Controller. This additional command is needed in order to support the commands returned to the Microkernel after it checks into a node that has been bound to the new `discovery_only` noop model that was recently added to Hanlon. Once we're sure this all works, the Hanlon and Hanlon-Microkernel projects will both be tagged and new releases of both projects will be constructed to enable these new noop models/policies.
