### PR TITLE
Reduce compression from insane level

### DIFF
--- a/iso-build-files/rebuild_iso.sh
+++ b/iso-build-files/rebuild_iso.sh
@@ -84,7 +84,7 @@ cd tmp
 find | cpio -o -H newc | gzip -9 > ../core.gz
 cd ..
 # compress the file and copy it to the correct location for building the ISO
-advdef -z4 core.gz
+advdef -z2 core.gz
 cp -p core.gz newiso/boot/
 # build the YAML file needed for use in Hanlon, place it into the root of the
 # ISO filesystem


### PR DESCRIPTION
Reduced build time by nearly  three minutes and doesn't change the size more than 250kb

       -4, --shrink-insane
              Set the compression level to "insane" using the zopfli compressor.  You can define the compressor iterations with the -i, --iter option.

       -2, --shrink-normal
              Set the compression level to "normal" using the 7z compressor.  This is the default level of compression.
