### PR TITLE
Fixes error detected when MK was run under recent versions of KVM

### DIFF
--- a/build-bundle-file.sh
+++ b/build-bundle-file.sh
@@ -183,7 +183,7 @@ fi
 [ -z "$TCL_ISO_URL" ] && TCL_ISO_URL='http://distro.ibiblio.org/tinycorelinux/5.x/x86/release/Core-current.iso'
 [ -z "$RUBY_GEMS_URL" ] && RUBY_GEMS_URL='http://production.cf.rubygems.org/rubygems/rubygems-1.8.24.tgz'
 [ -z "$PRIV_BUSYBOX_URL" ] && PRIV_BUSYBOX_URL='https://github.com/csc/Hanlon-Microkernel/releases/download/v2.0.0/mk-custom-busybox.tar.gz'
-[ -z "${DEB_PACKAGE_LIST_URL[*]}" ] && DEB_PACKAGE_LIST_URL[0]='http://distro.ibiblio.org/tinycorelinux/5.x/x86/debian_wheezy_main_i386_Packages.gz'
+[ -z "${DEB_PACKAGE_LIST_URL[*]}" ] && DEB_PACKAGE_LIST_URL[0]='http://tinycorelinux.net/dCore/x86/debian_wheezy_main_i386_Packages.gz'
 [ -z "$DEB_MIRROR_URL" ] && DEB_MIRROR_URL='ftp://ftp.us.debian.org/debian'
 
 # Save our top level directory; watch out for spaces!

--- a/hanlon_microkernel/hnl_mk_fact_manager.rb
+++ b/hanlon_microkernel/hnl_mk_fact_manager.rb
@@ -56,7 +56,11 @@ module HanlonMicrokernel
     end
 
     def get_uuid
-      %x[sudo dmidecode -s system-uuid].chomp
+      # we've seen multi-line output from dmidecode on some systems,
+      # so parse the result of the `sudo dmidecode -s system-uuid`
+      # command and assume the last line is the UUID
+      cmd_output = %x[sudo dmidecode -s system-uuid].chomp
+      cmd_output.split("\n")[-1]
     end
 
   end


### PR DESCRIPTION
The changes in this pull request modify how the SMBIOS UUID is obtained using the `dmidecode` command so that the proper results are returned, even when the command is run on a more recent KVM instance (where multi-line output was returned from the `dmidecode` command instead of a single line containing the SMBIOS UUID).

As part of the testing, we also detected an issue with the build process; recently the Tiny Core Linux site was modified so that the location of the `debian_wheezy_main_i386_Packages.gz` file was changed; this PR modifies the build script to download that file from the new location.