### PR TITLE
Add Network Driver for support HP Gen9

### DIFF
--- a/additional-build-files/builtin-extensions.lst
+++ b/additional-build-files/builtin-extensions.lst
@@ -1,3 +1,6 @@
+firmware-intel_e100.tcz
+firmware-broadcom_bcm43xx.tcz
+firmware.tcz
 firmware-broadcom_bnx2.tcz
 firmware-broadcom_bnx2x.tcz
 openssh.tcz


### PR DESCRIPTION
Kickstart on HP Proliant DL360 Gen9 don't working because MicroKernel don't have BCM driver.