### PR TITLE
Resolves issue when facter is updated upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
 FROM gliderlabs/alpine
 
+ENV FACTER_VERSION 2.4.6
+
 # Install any dependencies needed
 RUN apk update && \
     apk add bash sed dmidecode ruby ruby-irb open-lldp util-linux open-vm-tools sudo && \
     apk add lshw ipmitool --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted && \
     echo "install: --no-rdoc --no-ri" > /etc/gemrc && \
-    gem install facter json_pure daemons && \
-    find /usr/lib/ruby/gems/2.2.0/gems/facter-2.4.4 -type f -exec sed -i 's:/proc/:/host-proc/:g' {} + && \
-    find /usr/lib/ruby/gems/2.2.0/gems/facter-2.4.4 -type f -exec sed -i 's:/dev/:/host-dev/:g' {} + && \
-    find /usr/lib/ruby/gems/2.2.0/gems/facter-2.4.4 -type f -exec sed -i 's:/host-dev/null:/dev/null:g' {} + && \
-    find /usr/lib/ruby/gems/2.2.0/gems/facter-2.4.4 -type f -exec sed -i 's:/sys/:/host-sys/:g' {} +
+    gem install json_pure daemons && \
+    gem install facter -v ${FACTER_VERSION} && \
+    find /usr/lib/ruby/gems/2.2.0/gems/facter-${FACTER_VERSION} -type f -exec sed -i 's:/proc/:/host-proc/:g' {} + && \
+    find /usr/lib/ruby/gems/2.2.0/gems/facter-${FACTER_VERSION} -type f -exec sed -i 's:/dev/:/host-dev/:g' {} + && \
+    find /usr/lib/ruby/gems/2.2.0/gems/facter-${FACTER_VERSION} -type f -exec sed -i 's:/host-dev/null:/dev/null:g' {} + && \
+    find /usr/lib/ruby/gems/2.2.0/gems/facter-${FACTER_VERSION} -type f -exec sed -i 's:/sys/:/host-sys/:g' {} +
 ADD hnl_mk*.rb /usr/local/bin/
 ADD hanlon_microkernel/*.rb /usr/local/lib/ruby/hanlon_microkernel/


### PR DESCRIPTION
This update will resolve the issue if facter is updated upstream without changing the find in the dockerfile.

Listing the newly built microkernel
```bash
⚡ root@ubuntu-hanlon  ~/Hanlon-Microkernel   master ●  docker exec -it hanlon_server_1 ./cli/hanlon image 2Z1
Image:
 UUID =>  2Z1nbc8MMNpFq4xMZXGzBr
 Type =>  MicroKernel Image
 Name/Filename =>  rancheros.iso
 Status =>  Valid
 Version =>  3.0.0_dirty
 Built Time =>  2016-02-17 21:04:31 +0000
```
Listing the node after discovery, confirming facter is still functioning correctly.
```bash
  ⚡ root@ubuntu-hanlon  ~/Hanlon-Microkernel   master ●  docker exec -it hanlon_server_1 ./cli/hanlon node 58Z
Node:
 UUID =>  58Z0Z3GY2lqjOQ6BaS9AH5
 Last Checkin =>  02-18-16 03:53:26
 Status =>  active
 Tags =>  [memsize_2004MiB,kvm_vm]
 Hardware ID =>  [C2BFFAC2-53CF-41B1-96FD-E351BEE56531]
 ```